### PR TITLE
Prepare Trusted Publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,11 @@ jobs:
   build:
     name: Publish to Rubygems
     runs-on: ubuntu-latest
-
+    
+    permissions:
+      contents: write
+      id-token: write
+      
     steps:
       - uses: actions/checkout@v4
 
@@ -18,12 +22,4 @@ jobs:
           ruby-version: 2.7
 
       - name: Publish to RubyGems
-        run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem build faraday-httpclient.gemspec
-          gem push faraday-httpclient-*.gem
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
This PR makes the changes in the Workflow which makes use Trusted Publisher.  https://guides.rubygems.org/trusted-publishing/adding-a-publisher/

> [!NOTE]
> Merge this when the relevant RubyGems.org changes are in!